### PR TITLE
fix(ci): satisfy mypy in hook uninstaller

### DIFF
--- a/src/openclaw_enhance/install/uninstaller.py
+++ b/src/openclaw_enhance/install/uninstaller.py
@@ -92,23 +92,23 @@ def _remove_hooks(
             if isinstance(internal_obj, dict):
                 entries_obj = internal_obj.get("entries")
                 if isinstance(entries_obj, dict):
-                    filtered_entries = {
+                    filtered_entries_dict = {
                         key: value
                         for key, value in entries_obj.items()
                         if key not in OWNED_HOOK_ENTRY_IDS
                     }
-                    if filtered_entries != entries_obj:
-                        internal_obj["entries"] = filtered_entries
+                    if filtered_entries_dict != entries_obj:
+                        internal_obj["entries"] = filtered_entries_dict
                         removed.append("hooks:subagent-spawn-enrich")
                         changed = True
                 elif isinstance(entries_obj, list):
-                    filtered_entries = [
+                    filtered_entries_list = [
                         value
                         for value in entries_obj
                         if not (isinstance(value, str) and value in OWNED_HOOK_ENTRY_IDS)
                     ]
-                    if filtered_entries != entries_obj:
-                        internal_obj["entries"] = filtered_entries
+                    if filtered_entries_list != entries_obj:
+                        internal_obj["entries"] = filtered_entries_list
                         removed.append("hooks:subagent-spawn-enrich")
                         changed = True
 


### PR DESCRIPTION
## Summary
- fix the merged CI red light in `src/openclaw_enhance/install/uninstaller.py` by splitting the hook-entry list and dict branches into separate typed variables for mypy
- keep the previously added runtime registration, watchdog proof, and local deployment behavior unchanged

## Test Plan
- [x] `python -m mypy src/openclaw_enhance`
- [x] `pytest tests/integration/test_install_uninstall.py tests/integration/test_install_runtime_registration.py tests/integration/test_live_probes.py tests/integration/test_validation_real_env.py tests/unit/test_real_env_runner.py tests/unit/test_real_env_guardrails.py -q`