### PR TITLE
fix(ci): resolve monitor validation Ruff issues

### DIFF
--- a/src/openclaw_enhance/validation/types.py
+++ b/src/openclaw_enhance/validation/types.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
+import sys
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
 from pathlib import Path
-import sys
 
 
 class FeatureClass(Enum):

--- a/tests/integration/test_validation_real_env.py
+++ b/tests/integration/test_validation_real_env.py
@@ -11,7 +11,6 @@ Tests the validate-feature CLI command with mocked subprocess calls to verify:
 import json
 from pathlib import Path
 from unittest.mock import MagicMock, patch
-import sys
 
 import pytest
 from click.testing import CliRunner


### PR DESCRIPTION
## Summary
- fix the merged CI red light by cleaning up Ruff issues in the monitor install-lifecycle validation changes
- keep the monitor auto-start behavior unchanged while restoring Python lint green on main

## Test Plan
- [x] `python -m ruff check src tests`
- [x] `pytest tests/unit/test_real_env_validation.py tests/integration/test_validation_real_env.py tests/unit/test_monitor_runtime.py tests/integration/test_install_monitor_service.py tests/integration/test_install_uninstall.py tests/integration/test_install_idempotency.py -q`
- [x] `python -m openclaw_enhance.cli docs-check`