### PR TITLE
feat: add PLAYBOOK.md as system capability reference

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,7 @@
 | Workspace-specific rules | `workspaces/{name}/AGENTS.md` |
 | Worker routing metadata | AGENTS.md frontmatter in each workspace |
 | Worker tool definitions | `workspaces/{name}/TOOLS.md` |
+| System capability playbook | `PLAYBOOK.md` (安装时部署到 `~/.openclaw/openclaw-enhance/PLAYBOOK.md`) |
 
 ## Session State vs Permanent Memory
 
@@ -92,7 +93,19 @@ After completing any feature development:
   - [ ] `python -m openclaw_enhance.cli validate-feature --feature-class <class> --report-slug <slug>` passes
   - [ ] Validation report saved to `docs/reports/`
 - [ ] `python -m openclaw_enhance.cli docs-check` passes
+- [ ] **PLAYBOOK.md 已更新**（如果本次变更影响了以下任何内容）：
+  - Agent 新增/删除/职责变更
+  - Hook 新增/删除/行为变更
+  - Skill 新增/删除/行为变更
+  - Extension 变更
+  - openclaw.json 配置修改项变更
+  - 安装产物（新增/删除文件或目录）
+  - 工具限制（Tool Gate）规则变更
+  - Watchdog/监控机制变更
+  - CLI 命令新增/删除
 
 **Critical Rule**: Features cannot be merged without a successful real-environment validation report in `docs/reports/`. Unit/integration tests verify code correctness, but only real-environment testing verifies actual functionality in the OpenClaw environment.
+
+**Critical Rule**: `PLAYBOOK.md` 是系统能力的权威清单，安装时会部署到 `~/.openclaw/openclaw-enhance/PLAYBOOK.md` 供 AI 和人类查阅。每次 commit 前必须检查是否需要同步更新。
 
 See `docs/testing-playbook.md` for the feature-class matrix and detailed validation procedures.

--- a/PLAYBOOK.md
+++ b/PLAYBOOK.md
@@ -1,0 +1,96 @@
+## 概述
+openclaw-enhance 是一个针对 OpenClaw 的非侵入式增强组件。它通过扩展点、钩子和独立工作区，在不修改 OpenClaw 核心源码的前提下，实现了多任务并行处理、自动化运维监控以及操作透明化。
+
+## 安装产物清单
+```
+~/.openclaw/
+├── openclaw.json                    # 被修改：agents.list, hooks.internal
+├── openclaw-enhance/                # 托管命名空间
+│   ├── PLAYBOOK.md                  # 本文件
+│   ├── install-manifest.json        # 安装清单（组件、版本、回滚点）
+│   ├── runtime-state.json           # 运行时状态（超时、健康检查）
+│   ├── workspaces/                  # 6 个 Worker Agent 工作区
+│   │   ├── oe-orchestrator/         # 编排调度 Agent
+│   │   ├── oe-searcher/             # 搜索研究 Agent
+│   │   ├── oe-syshelper/            # 系统自省 Agent
+│   │   ├── oe-script_coder/         # 脚本开发 Agent
+│   │   ├── oe-watchdog/             # 会话监控 Agent
+│   │   └── oe-tool-recovery/        # 工具故障恢复 Agent
+│   ├── hooks/                       # Hook 实现
+│   │   ├── oe-main-routing-gate/    # 复杂任务路由钩子
+│   │   └── oe-subagent-spawn-enrich/# 子 Agent 派发增强钩子
+│   └── logs/                        # 监控日志
+│       ├── monitor.log
+│       └── monitor.err.log
+├── workspace/                       # 主工作区（被修改）
+│   ├── AGENTS.md                    # 被注入工具限制（tool gate）
+│   └── skills/                      # 主会话 Skill
+│       ├── oe-toolcall-router/      # 路由决策 Skill
+│       ├── oe-eta-estimator/        # 任务时长估算 Skill
+│       └── oe-timeout-state-sync/   # 超时状态同步 Skill
+└── extensions/                      # OpenClaw 扩展目录
+    └── oe-runtime/                  # 运行时桥接扩展
+~/Library/LaunchAgents/              # (仅 macOS)
+└── ai.openclaw.enhance.monitor.plist # 后台监控服务（每60秒）
+```
+
+## Agent 清单
+| Agent ID | 职责 | 模型策略 | 权限 |
+| :--- | :--- | :--- | :--- |
+| oe-orchestrator | 编排调度，负责计划、派发与结果合成 | 最强模型 | 全权限 |
+| oe-searcher | 搜索研究，执行 Web 搜索与文档查找 | 廉价模型 | 只读 |
+| oe-syshelper | 系统自省，执行 grep、ls、find 等操作 | 廉价模型 | 只读 |
+| oe-script_coder | 脚本开发，编写代码并运行测试 | 标准模型 | 沙箱读写 |
+| oe-watchdog | 会话监控，负责超时检测与主动提醒 | 廉价模型 | 仅限运行时状态 |
+| oe-tool-recovery | 工具故障恢复，进行诊断并提供修复建议 | 推理模型 | 只读 |
+
+## Hook 清单
+| Hook ID | 触发时机 | 作用 |
+| :--- | :--- | :--- |
+| oe-main-routing-gate | message preprocessed 时 | 检测复杂任务，注入路由建议 |
+| oe-subagent-spawn-enrich | subagent_spawning 时 | 注入 task_id、project、eta_bucket、dedupe_key |
+
+## Skill 清单
+| Skill ID | 安装位置 | 作用 |
+| :--- | :--- | :--- |
+| oe-toolcall-router | 主工作区 | 强制主会话仅执行路由功能，所有具体执行均通过 sessions_spawn 完成 |
+| oe-eta-estimator | 主工作区 | 估算任务的时长与复杂度 |
+| oe-timeout-state-sync | 主工作区 | 在主会话与运行时存储之间同步超时状态 |
+
+## Extension 清单
+- oe-runtime: before_tool_call 扩展。该扩展会阻止主会话使用 edit、write、exec 等被禁止的工具。
+
+## 主会话工具限制（Tool Gate）
+主会话（main）的 AGENTS.md 文件被注入了工具限制。系统禁止主会话使用 edit、write、exec、web_search 和 browser。主会话仅允许使用 read、memory_search 和 sessions_spawn 等工具。这一设计的目的是强制主会话扮演路由器的角色，将具体任务分发给专门的 Worker Agent。
+
+## openclaw.json 修改清单
+| 配置路径 | 修改内容 |
+| :--- | :--- |
+| agents.list | 添加 6 个托管 Agent（managed agents） |
+| agents.list[main].subagents.allowAgents | 添加 oe-orchestrator |
+| hooks.internal.entries | 启用 oe-subagent-spawn-enrich 和 oe-main-routing-gate |
+| hooks.internal.enabled | 设置为 true |
+| hooks.internal.load.extraDirs | 添加 hooks 目录的路径 |
+| plugins.entries.oe-runtime | 启用运行时扩展 |
+
+## Watchdog 监控机制
+在 macOS 环境下，LaunchAgent 每 60 秒运行一次 monitor_runtime。该程序会检测超时的会话，并将结果写入 runtime-state.json。oe-watchdog 在确认超时后会向用户发送提醒。
+
+## CLI 命令速查
+| 命令 | 说明 |
+| :--- | :--- |
+| python -m openclaw_enhance.cli status | 查看安装状态 |
+| python -m openclaw_enhance.cli doctor | 执行健康检查 |
+| python -m openclaw_enhance.cli render-skill <name> | 查看指定 Skill 的合约内容 |
+| python -m openclaw_enhance.cli render-workspace <name> | 查看工作区的配置信息 |
+| python -m openclaw_enhance.cli validate-feature | 在真实环境中进行功能验证 |
+
+## 安装与卸载
+安装命令：
+`python -m openclaw_enhance.cli install`
+
+卸载命令：
+`python -m openclaw_enhance.cli uninstall`
+
+## 版本
+Playbook Version: 1.0.0

--- a/src/openclaw_enhance/install/installer.py
+++ b/src/openclaw_enhance/install/installer.py
@@ -261,6 +261,25 @@ def _sync_hooks(target_root: Path, dev_mode: bool = False) -> list[ComponentInst
     return components
 
 
+def _sync_playbook(target_root: Path) -> ComponentInstall | None:
+    """Copy PLAYBOOK.md to managed root for AI/human reference."""
+    source_path = Path(__file__).resolve().parents[3] / "PLAYBOOK.md"
+    if not source_path.exists():
+        return None
+
+    target_path = target_root / "PLAYBOOK.md"
+    shutil.copy2(source_path, target_path)
+
+    return ComponentInstall(
+        name="playbook",
+        version=VERSION,
+        install_time=datetime.utcnow(),
+        source_path=str(source_path.absolute()),
+        target_path=str(target_path.absolute()),
+        is_symlink=False,
+    )
+
+
 def _write_openclaw_config(config_path: Path, config: dict[str, Any]) -> str:
     backup_path = config_path.with_name(f"{config_path.name}.bak")
     temp_path = config_path.with_name(f"{config_path.name}.tmp")
@@ -583,7 +602,13 @@ def install(
             all_components.append(runtime_component)
         except Exception as exc:
             errors.append(f"Runtime state initialization failed: {exc}")
-            # Non-fatal - continue
+
+        try:
+            playbook_component = _sync_playbook(target_root)
+            if playbook_component is not None:
+                all_components.append(playbook_component)
+        except Exception as exc:
+            errors.append(f"Playbook sync failed: {exc}")
 
         try:
             monitor_service_component = install_monitor_launchagent(

--- a/src/openclaw_enhance/install/uninstaller.py
+++ b/src/openclaw_enhance/install/uninstaller.py
@@ -504,6 +504,14 @@ def uninstall(
         lock_removed = _remove_lock_file(target_root)
         removed.extend(lock_removed)
 
+        playbook_file = target_root / "PLAYBOOK.md"
+        if playbook_file.exists():
+            try:
+                playbook_file.unlink()
+                removed.append("playbook")
+            except OSError as exc:
+                failed.append(f"playbook: {exc}")
+
         if target_root.exists():
             try:
                 # Only remove if directory is empty or contains only empty subdirs

--- a/tests/integration/test_install_uninstall.py
+++ b/tests/integration/test_install_uninstall.py
@@ -115,6 +115,24 @@ class TestInstallUninstallSymmetry:
         assert "main-skill:oe-toolcall-router" in component_names
         assert "main-skill:oe-timeout-state-sync" in component_names
 
+    def test_install_deploys_playbook(
+        self,
+        mock_openclaw_home: Path,
+        isolated_user_home: Path,
+    ) -> None:
+        """Install should copy PLAYBOOK.md to managed root."""
+        result = install(mock_openclaw_home, user_home=isolated_user_home)
+        assert result.success
+
+        target_root = managed_root(isolated_user_home)
+        playbook_path = target_root / "PLAYBOOK.md"
+        assert playbook_path.exists()
+        assert playbook_path.stat().st_size > 0
+
+        manifest = load_manifest(target_root)
+        assert manifest is not None
+        assert "playbook" in [c.name for c in manifest.components]
+
     def test_status_reports_installed(
         self,
         mock_openclaw_home: Path,

--- a/tests/integration/test_spawn_event_contract.py
+++ b/tests/integration/test_spawn_event_contract.py
@@ -50,7 +50,7 @@ class TestSpawnEventContract:
         import json
 
         pkg = json.loads(pkg_path.read_text())
-        assert pkg["name"] == "@openclaw-enhance/runtime"
+        assert pkg["name"] == "@openclaw-enhance/oe-runtime"
         assert "exports" in pkg
 
     def test_extension_plugin_config_exists(self):
@@ -214,6 +214,22 @@ class TestTypeScriptCompilation:
             if "openclaw-enhance-runtime" in line or "hooks/oe-subagent" in line
         ]
         assert len(extension_errors) == 0, f"TypeScript errors: {extension_errors}"
+
+
+class TestPlaybookExists:
+    """Verify PLAYBOOK.md exists in project root."""
+
+    def test_playbook_file_exists(self):
+        """PLAYBOOK.md must exist at project root for installer to deploy."""
+        playbook_path = PROJECT_ROOT / "PLAYBOOK.md"
+        assert playbook_path.exists(), f"PLAYBOOK.md not found: {playbook_path}"
+
+    def test_playbook_has_required_sections(self):
+        """PLAYBOOK.md must contain all required sections."""
+        content = (PROJECT_ROOT / "PLAYBOOK.md").read_text()
+        required = ["Agent", "Hook", "Skill", "Extension", "Tool Gate", "openclaw.json", "CLI"]
+        for section in required:
+            assert section in content, f"Missing section containing '{section}'"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Add `PLAYBOOK.md` as the authoritative capability reference for openclaw-enhance
- Installer deploys it to `~/.openclaw/openclaw-enhance/PLAYBOOK.md` for AI and human inspection
- Post-development checklist in `AGENTS.md` now requires PLAYBOOK.md sync on every commit

## Changes

- **PLAYBOOK.md** (new): Structured inventory in Chinese covering all agents, hooks, skills, extensions, tool gate rules, openclaw.json modifications, watchdog mechanism, and CLI commands
- **installer.py**: `_sync_playbook()` copies PLAYBOOK.md to managed root during install
- **uninstaller.py**: Cleans up PLAYBOOK.md during uninstall
- **AGENTS.md**: Added Source of Truth entry + mandatory post-dev checklist item for PLAYBOOK.md maintenance
- **test_install_uninstall.py**: New test `test_install_deploys_playbook`
- **test_spawn_event_contract.py**: New `TestPlaybookExists` class + fix stale `@openclaw-enhance/runtime` → `@openclaw-enhance/oe-runtime` assertion

## Verification

- [x] 580 tests pass (unit + integration)
- [x] docs-check passes
- [x] PLAYBOOK.md deployed to live install at `~/.openclaw/openclaw-enhance/`