### PR TITLE
fix: eliminate oe-runtime plugin provenance warning on startup

### DIFF
--- a/extensions/openclaw-enhance-runtime/openclaw.plugin.json
+++ b/extensions/openclaw-enhance-runtime/openclaw.plugin.json
@@ -5,7 +5,7 @@
   "displayName": "OpenClaw Enhance Runtime Bridge",
   "description": "Runtime integration bridge for OpenClaw Enhance",
   "type": "extension",
-  "entryPoint": "./index.js",
+  "entryPoint": "./index.ts",
   "namespace": "oe",
   "configSchema": {
     "type": "object",

--- a/extensions/openclaw-enhance-runtime/package.json
+++ b/extensions/openclaw-enhance-runtime/package.json
@@ -3,10 +3,9 @@
   "version": "0.1.0",
   "description": "OpenClaw extension for runtime integration bridge",
   "type": "module",
-  "main": "./index.js",
-  "types": "./index.d.ts",
+  "main": "./index.ts",
   "openclaw": {
-    "extensions": ["./index.js"]
+    "extensions": ["./index.ts"]
   },
   "exports": {
     ".": {

--- a/src/openclaw_enhance/install/installer.py
+++ b/src/openclaw_enhance/install/installer.py
@@ -41,6 +41,7 @@ from openclaw_enhance.paths import (
 )
 from openclaw_enhance.runtime.ownership import (
     OWNED_AGENT_SPECS,
+    OWNED_EXTENSION_ID,
     OWNED_HOOK_ENTRY_IDS,
     OWNED_NAMESPACE,
 )
@@ -401,6 +402,56 @@ def _register_agents_via_cli(
     return components
 
 
+# Extension source directory (relative to this file: src/openclaw_enhance/install/ -> extensions/)
+_EXTENSION_SOURCE_DIR = (
+    Path(__file__).resolve().parents[3] / "extensions" / "openclaw-enhance-runtime"
+)
+
+
+def _install_extension() -> ComponentInstall | None:
+    """Install the oe-runtime plugin via ``openclaw plugins install --link``.
+
+    Using --link records proper install provenance in openclaw.json, which
+    eliminates the "loaded without install/load-path provenance" warning.
+    ``openclaw plugins install`` also handles plugins.allow automatically.
+    """
+    if not _EXTENSION_SOURCE_DIR.exists():
+        return None
+
+    source_path = str(_EXTENSION_SOURCE_DIR.absolute())
+
+    # Uninstall first if already tracked (idempotent reinstall)
+    check = _run_openclaw_cli(["plugins", "list", "--json"], check=False)
+    already_installed = False
+    if check.returncode == 0:
+        try:
+            data = json.loads(check.stdout)
+            already_installed = any(
+                isinstance(p, dict) and p.get("id") == OWNED_EXTENSION_ID for p in data
+            )
+        except (json.JSONDecodeError, TypeError):
+            pass
+
+    if already_installed:
+        _run_openclaw_cli(["plugins", "uninstall", "--force", OWNED_EXTENSION_ID], check=False)
+
+    result = _run_openclaw_cli(
+        ["plugins", "install", "--link", source_path],
+        check=False,
+    )
+    if result.returncode != 0 and "already exists" not in (result.stdout + result.stderr):
+        raise InstallError(f"Failed to install extension {OWNED_EXTENSION_ID}: {result.stderr}")
+
+    return ComponentInstall(
+        name=f"extension:{OWNED_EXTENSION_ID}",
+        version=VERSION,
+        install_time=datetime.utcnow(),
+        source_path=source_path,
+        target_path=source_path,
+        is_symlink=True,
+    )
+
+
 def _register_runtime_surfaces(
     manifest: InstallManifest,
     openclaw_home: Path,
@@ -461,19 +512,6 @@ def _register_runtime_surfaces(
     if managed_hooks_dir not in extra_dirs:
         extra_dirs.append(managed_hooks_dir)
     load_obj["extraDirs"] = extra_dirs
-
-    plugins_obj = config.get("plugins")
-    if not isinstance(plugins_obj, dict):
-        plugins_obj = {}
-        config["plugins"] = plugins_obj
-
-    allow_list = plugins_obj.get("allow")
-    if not isinstance(allow_list, list):
-        allow_list = []
-        plugins_obj["allow"] = allow_list
-
-    if "oe-runtime" not in allow_list:
-        allow_list.append("oe-runtime")
 
     try:
         backup_path = _write_openclaw_config(config_path, config)
@@ -711,6 +749,14 @@ def install(
         except Exception as exc:
             errors.append(f"Runtime registration failed: {exc}")
             raise InstallError(f"Runtime registration failed: {exc}") from exc
+
+        try:
+            ext_component = _install_extension()
+            if ext_component is not None:
+                all_components.append(ext_component)
+        except Exception as exc:
+            errors.append(f"Extension install failed: {exc}")
+            raise InstallError(f"Extension install failed: {exc}") from exc
 
         try:
             model_config_components = _configure_agent_models(

--- a/src/openclaw_enhance/install/uninstaller.py
+++ b/src/openclaw_enhance/install/uninstaller.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import json
 import os
 import shutil
+import subprocess
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -40,6 +41,7 @@ from openclaw_enhance.paths import (
 )
 from openclaw_enhance.runtime.ownership import (
     OWNED_AGENT_SPECS,
+    OWNED_EXTENSION_ID,
     OWNED_HOOK_ENTRY_IDS,
     OWNED_NAMESPACE,
 )
@@ -167,17 +169,6 @@ def _remove_hooks(
                 del config["hooks"]
                 changed = True
 
-        plugins_obj = config.get("plugins")
-        if isinstance(plugins_obj, dict):
-            allow_list = plugins_obj.get("allow")
-            if isinstance(allow_list, list) and "oe-runtime" in allow_list:
-                allow_list.remove("oe-runtime")
-                changed = True
-                if not allow_list:
-                    del plugins_obj["allow"]
-                if not plugins_obj:
-                    del config["plugins"]
-
         if OWNED_NAMESPACE in config:
             del config[OWNED_NAMESPACE]
             changed = True
@@ -264,6 +255,23 @@ def _unregister_agents(
         return removed
     except (json.JSONDecodeError, OSError, KeyError) as exc:
         raise UninstallError(f"Failed to unregister agents: {exc}") from exc
+
+
+def _uninstall_extension() -> list[str]:
+    """Uninstall the oe-runtime plugin via ``openclaw plugins uninstall --force``."""
+    removed: list[str] = []
+    try:
+        result = subprocess.run(
+            ["openclaw", "plugins", "uninstall", "--force", OWNED_EXTENSION_ID],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode == 0 or "not found" in (result.stdout + result.stderr).lower():
+            removed.append(f"extension:{OWNED_EXTENSION_ID}")
+    except FileNotFoundError:
+        pass  # openclaw CLI not available; skip
+    return removed
 
 
 def _remove_hook_assets(target_root: Path) -> list[str]:
@@ -435,7 +443,15 @@ def uninstall(
             if not force:
                 raise
 
-        # Step 2: Remove hooks
+        # Step 2a: Uninstall oe-runtime extension
+        try:
+            ext_removed = _uninstall_extension()
+            removed.extend(ext_removed)
+        except Exception as exc:
+            failed.append(f"extension: {exc}")
+            # Non-fatal — continue uninstall
+
+        # Step 2b: Remove hooks
         try:
             hooks_removed = _remove_hooks(manifest or InstallManifest(), openclaw_home)
             removed.extend(hooks_removed)

--- a/src/openclaw_enhance/runtime/ownership.py
+++ b/src/openclaw_enhance/runtime/ownership.py
@@ -18,6 +18,8 @@ OWNED_HOOK_ENTRY_IDS: tuple[str, ...] = (
     "oe-main-routing-gate",
 )
 
+OWNED_EXTENSION_ID = "oe-runtime"
+
 
 def filter_owned_keys(
     patch: Mapping[str, Any], namespace: str = OWNED_NAMESPACE

--- a/tests/integration/test_spawn_event_contract.py
+++ b/tests/integration/test_spawn_event_contract.py
@@ -66,7 +66,7 @@ class TestSpawnEventContract:
         assert config["name"] == "openclaw-enhance-runtime"
         assert config["namespace"] == "oe"
         assert config["type"] == "extension"
-        assert config["entryPoint"] == "./index.js"
+        assert config["entryPoint"] == "./index.ts"
 
     def test_extension_index_exists(self):
         """Verify extension index.ts exists with tool-gate registration."""


### PR DESCRIPTION
Fixes #25

## 问题

每次 OpenClaw 启动都会打印黄色警告：
```
[plugins] oe-runtime: loaded without install/load-path provenance; treat as untracked local code...
```

## 根本原因

1. 安装器手动往 `plugins.allow` 追加 `"oe-runtime"`，跳过了 `openclaw plugins install` 流程，没有写 `plugins.installs` provenance 记录
2. `package.json` 和 `openclaw.plugin.json` 的入口点指向 `./index.js`（不存在），导致正确的 CLI 安装方式报错 `extension entry escapes package directory`

## 修改

| 文件 | 变更 |
|------|------|
| `extensions/openclaw-enhance-runtime/package.json` | entry point `./index.js` → `./index.ts` |
| `extensions/openclaw-enhance-runtime/openclaw.plugin.json` | `entryPoint` `./index.js` → `./index.ts` |
| `src/openclaw_enhance/install/installer.py` | 新增 `_install_extension()`，调用 `openclaw plugins install --link`；移除手动 `plugins.allow` 操作 |
| `src/openclaw_enhance/install/uninstaller.py` | 新增 `_uninstall_extension()`，调用 `openclaw plugins uninstall --force`；移除手动 `plugins.allow` 清理 |
| `src/openclaw_enhance/runtime/ownership.py` | 新增 `OWNED_EXTENSION_ID = "oe-runtime"` 常量 |
| `tests/integration/test_spawn_event_contract.py` | 更新断言：`entryPoint == "./index.ts"` |

## 验证

本地验证：
- `openclaw plugins list` 不再出现 provenance 警告 ✅
- `python -m openclaw_enhance.cli install --force` 成功，组件列表含 `extension:oe-runtime` ✅  
- `python -m openclaw_enhance.cli uninstall` 干净移除 ✅
- 351 unit tests pass, 642 integration tests pass ✅
- mypy / ruff / typecheck / lint 全部通过 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)