### PR TITLE
fix: enforce tool gate at runtime — oe-runtime install order + web_search/web_fetch block

### DIFF
--- a/extensions/openclaw-enhance-runtime/index.ts
+++ b/extensions/openclaw-enhance-runtime/index.ts
@@ -9,7 +9,9 @@ const MAIN_FORBIDDEN_TOOLS = new Set([
   "exec", // bash is named exec internally
   "process",
   "browser",
-  "playwright"
+  "playwright",
+  "web_search",
+  "web_fetch",
 ]);
 
 export default {

--- a/src/openclaw_enhance/install/installer.py
+++ b/src/openclaw_enhance/install/installer.py
@@ -408,19 +408,22 @@ _EXTENSION_SOURCE_DIR = (
 )
 
 
-def _install_extension() -> ComponentInstall | None:
-    """Install the oe-runtime plugin via ``openclaw plugins install --link``.
+def _verify_extension_in_config(openclaw_home: Path | None = None) -> bool:
+    home = openclaw_home or Path.home() / ".openclaw"
+    config_path = resolve_openclaw_config_path(home)
+    config = _load_openclaw_config(config_path)
+    plugins = config.get("plugins", {})
+    allow_list = plugins.get("allow", [])
+    entries = plugins.get("entries", {})
+    return OWNED_EXTENSION_ID in allow_list and OWNED_EXTENSION_ID in entries
 
-    Using --link records proper install provenance in openclaw.json, which
-    eliminates the "loaded without install/load-path provenance" warning.
-    ``openclaw plugins install`` also handles plugins.allow automatically.
-    """
+
+def _install_extension(openclaw_home: Path | None = None) -> ComponentInstall | None:
     if not _EXTENSION_SOURCE_DIR.exists():
         return None
 
     source_path = str(_EXTENSION_SOURCE_DIR.absolute())
 
-    # Uninstall first if already tracked (idempotent reinstall)
     check = _run_openclaw_cli(["plugins", "list", "--json"], check=False)
     already_installed = False
     if check.returncode == 0:
@@ -441,6 +444,12 @@ def _install_extension() -> ComponentInstall | None:
     )
     if result.returncode != 0 and "already exists" not in (result.stdout + result.stderr):
         raise InstallError(f"Failed to install extension {OWNED_EXTENSION_ID}: {result.stderr}")
+
+    if not _verify_extension_in_config(openclaw_home):
+        raise InstallError(
+            f"Extension {OWNED_EXTENSION_ID} was installed but not found in "
+            f"openclaw.json plugins config. The CLI may have failed silently."
+        )
 
     return ComponentInstall(
         name=f"extension:{OWNED_EXTENSION_ID}",
@@ -751,14 +760,6 @@ def install(
             raise InstallError(f"Runtime registration failed: {exc}") from exc
 
         try:
-            ext_component = _install_extension()
-            if ext_component is not None:
-                all_components.append(ext_component)
-        except Exception as exc:
-            errors.append(f"Extension install failed: {exc}")
-            raise InstallError(f"Extension install failed: {exc}") from exc
-
-        try:
             model_config_components = _configure_agent_models(
                 manifest,
                 openclaw_home,
@@ -767,6 +768,19 @@ def install(
             all_components.extend(model_config_components)
         except Exception as exc:
             errors.append(f"Agent model configuration failed: {exc}")
+
+        # Extension install MUST be after all _write_openclaw_config calls.
+        # openclaw plugins install --link writes to openclaw.json directly;
+        # if _configure_agent_models (or any other function that does
+        # load→modify→write on openclaw.json) runs AFTER, it will overwrite
+        # the plugins.allow/entries that the CLI just added.
+        try:
+            ext_component = _install_extension(openclaw_home=openclaw_home)
+            if ext_component is not None:
+                all_components.append(ext_component)
+        except Exception as exc:
+            errors.append(f"Extension install failed: {exc}")
+            raise InstallError(f"Extension install failed: {exc}") from exc
 
         # Step 7: Initialize runtime state
         try:

--- a/src/openclaw_enhance/install/main_tool_gate.py
+++ b/src/openclaw_enhance/install/main_tool_gate.py
@@ -26,7 +26,7 @@ TOOL_GATE_BLOCK = f"""{TOOL_GATE_MARKER}
 **当用户要求任何需要修改文件、执行命令、搜索研究的任务时：**
 1. 必须使用 `sessions_spawn` 派发给 `oe-orchestrator`
 2. 绝对不要自己动手，即使任务看起来很简单
-3. 如果你发现自己想调用 `edit`/`exec`/`write`，立刻停下来，改用 `sessions_spawn`
+3. 如果你发现自己想调用 `edit`/`exec`/`write`/`web_search`/`web_fetch`，立刻停下来，改用 `sessions_spawn`
 {TOOL_GATE_MARKER}"""
 
 

--- a/workspaces/oe-orchestrator/AGENTS.md
+++ b/workspaces/oe-orchestrator/AGENTS.md
@@ -29,9 +29,10 @@ routing:
 
 - 把 frontmatter 当作运行时发现元数据；worker 选择依赖 `workspaces/*/AGENTS.md` 的 frontmatter，而不是正文长描述。
 - 先读 `TOOLS.md` 里的本地路径和仓库约定；不要把它当成第二份技能手册。
-- **首先加载 `oe-memory-sync`**：主动获取 Main Session 的上下文（parent_session 历史、main memory 文件、project context）。
+- **首先加载 `oe-memory-sync`**：主动获取 Main Session 的上下文（parent_session 历史、main memory 文件、project context、**Main 的 TOOLS.md**）。
+  - Orchestrator 是 Main 的分身，必须继承 Main 的工具知识。Main 的 TOOLS.md 描述了系统可用的完整工具集、使用限制和配置，Orchestrator 在规划和 dispatch 时需要这些信息来准确判断能力边界。
 - 根据任务加载对应 skill：
-  - `oe-memory-sync`：获取 Main 会话上下文，理解用户之前和 main 聊了什么
+  - `oe-memory-sync`：获取 Main 会话上下文，理解用户之前和 main 聊了什么，以及 Main 拥有的工具集
   - `oe-project-registry`：项目发现、注册表位置、项目类型判断
   - `oe-worker-dispatch`：dispatch loop、checkpoint visibility、recovery flow、result synthesis
   - `oe-git-context`：git 历史和上下文注入
@@ -51,21 +52,13 @@ routing:
 
 ## Skills
 
-- `oe-memory-sync`：获取 Main Session 上下文（parent_session 历史、memory 文件、project context）
+- `oe-memory-sync`：获取 Main Session 上下文（parent_session 历史、memory 文件、project context、**Main TOOLS.md**）
 - `oe-project-registry`：发现项目、记录项目路径、给 dispatch 提供项目范围
-- `oe-worker-dispatch`：负责任务拆分、worker 选择、轮次推进、恢复分支与汇总格式
-- `oe-git-context`：为 worker prompt 注入最近变更、文件历史与相关提交
-- `oe-agentos-practice`：提供规划、实现、测试与重构约定
-
-## Skills
-
-- `oe-memory-sync`：获取 Main Session 上下文（parent_session 历史、memory 文件、project context）
-- `oe-project-registry`：发现项目、记录项目路径、给 dispatch 提供项目范围
-- `oe-worker-dispatch`：负责任务拆分、worker 选择、轮次推进、恢复分支与汇总格式、**dispatch context enrichment**
+- `oe-worker-dispatch`：负责任务拆分、worker 选择、轮次推进、恢复分支与汇总格式、**dispatch context enrichment（含 main tools）**
 - `oe-git-context`：为 worker prompt 注入最近变更、文件历史与相关提交
 - `oe-agentos-practice`：提供规划、实现、测试与重构约定
 
 ## Version
 
-Version: 1.3.0
-Last Updated: 2026-03-19
+Version: 1.4.0
+Last Updated: 2026-03-20

--- a/workspaces/oe-orchestrator/skills/oe-memory-sync/SKILL.md
+++ b/workspaces/oe-orchestrator/skills/oe-memory-sync/SKILL.md
@@ -84,6 +84,32 @@ registry = read("~/.openclaw/openclaw-enhance/project-registry.json")
 # - Git associations
 ```
 
+### 5. Main TOOLS.md
+
+Main's `TOOLS.md` describes the tool landscape visible to main session. Since the Orchestrator is Main's delegate for complex tasks, it must inherit Main's tool knowledge to make informed dispatch and planning decisions.
+
+```python
+# Main workspace path follows OpenClaw config resolution:
+#   1. openclaw.json → agent.workspace (if set)
+#   2. OPENCLAW_PROFILE env → ~/.openclaw/workspace-{profile}
+#   3. Default → ~/.openclaw/workspace
+#
+# TOOLS.md location:
+main_tools_path = f"{main_workspace_path}/TOOLS.md"
+
+main_tools = read(main_tools_path)
+# Contains:
+# - Available MCP servers and their tool lists
+# - Tool usage guidelines and restrictions
+# - Custom tool configurations
+# - Tool aliases and preferred invocations
+```
+
+**Why this matters:**
+- Orchestrator needs to know which tools exist system-wide to correctly scope worker tasks
+- Some tools are only available at main level; Orchestrator must know this boundary
+- Tool restrictions/guidelines from main apply transitively to Orchestrator's planning
+
 ## Usage Pattern
 
 ### Session Startup Flow
@@ -105,6 +131,9 @@ Fetch Main Memory ──► read memory/*.md files
     │
     ▼
 Fetch Project Context ──► runtime-state.json + project-registry.json
+    │
+    ▼
+Fetch Main Tools ──► read {main_workspace}/TOOLS.md
     │
     ▼
 Synthesize Context
@@ -138,12 +167,18 @@ async def sync_main_context():
     active_project = runtime_state.get("active_project")
     project_info = registry.get_project(active_project) if active_project else None
     
-    # 5. Synthesize into context
+    # 5. Fetch Main TOOLS.md
+    main_workspace_path = resolve_main_workspace()  # ~/.openclaw/workspace
+    main_tools_path = f"{main_workspace_path}/TOOLS.md"
+    main_tools = read(main_tools_path) if file_exists(main_tools_path) else ""
+    
+    # 6. Synthesize into context
     context = {
         "parent_history_summary": history_summary,
         "main_memory": memory_content,
         "active_project": project_info,
         "parent_session_id": parent_session,
+        "main_tools": main_tools,
     }
     
     return context
@@ -156,7 +191,7 @@ After fetching, inject the context into Orchestrator's understanding:
 ```python
 def inject_orch_context(context):
     """Inject fetched context into Orchestrator prompt."""
-    return f"""
+    parts = [f"""
 ## Main Session Context
 
 ### Prior Conversation Summary
@@ -167,13 +202,25 @@ def inject_orch_context(context):
 
 ### Active Project
 {format_project_info(context['active_project'])}
+"""]
 
+    # Include Main's tool landscape if available
+    if context.get('main_tools'):
+        parts.append(f"""
+### Main Tools
+{context['main_tools']}
+""")
+
+    parts.append(f"""
 ### Task
 {current_task_description}
 
 Use the above context to better understand the user's intent and
 provide more informed orchestration decisions.
-"""
+The Main Tools section describes the full tool landscape available to main session.
+Use this to inform dispatch decisions and worker task scoping.
+""")
+    return "\n".join(parts)
 ```
 
 ## Summarization Strategy
@@ -257,6 +304,7 @@ This skill never:
 | Parent session not found | Log error, continue without history |
 | Memory files missing | Continue without memory, log info |
 | Runtime state unavailable | Use defaults, log warning |
+| Main TOOLS.md missing | Continue with empty main_tools, log info |
 
 ## Example
 
@@ -269,6 +317,9 @@ async def on_session_start():
     if ctx["parent_history_summary"]:
         print(f"📋 Parent conversation context available")
         print(f"   Project: {ctx['active_project']}")
+    
+    if ctx.get("main_tools"):
+        print(f"🔧 Main tool landscape loaded")
     
     # Now proceed with task understanding
     task = current_task()
@@ -288,6 +339,7 @@ context:
     name: string
     path: string
     type: permanent | temporary
+  main_tools: string          # Content of Main's TOOLS.md (empty string if unavailable)
   timestamp: ISO8601
   status: complete | partial | unavailable
 ```

--- a/workspaces/oe-orchestrator/skills/oe-worker-dispatch/SKILL.md
+++ b/workspaces/oe-orchestrator/skills/oe-worker-dispatch/SKILL.md
@@ -536,6 +536,7 @@ Before calling `sessions_spawn`, enrich the task prompt with relevant context fr
 | Context | Source Skill | What to Include |
 |---------|-------------|------------------|
 | Main session history | `oe-memory-sync` | Parent conversation summary, user intent |
+| Main tool landscape | `oe-memory-sync` | Main's TOOLS.md — available MCP servers, tool restrictions, usage guidelines |
 | Git context | `oe-git-context` | Recent commits, changed files, related history |
 | Project info | `oe-project-registry` | Project type, path, branch status, coding conventions |
 
@@ -552,10 +553,10 @@ Before sessions_spawn:
     │                          (recent commits, changed files)
     ▼
 3. Load memory context ───► oe-memory-sync
-    │                          (parent session summary)
+    │                          (parent session summary + main tools)
     ▼
 4. Synthesize enriched task
-    │
+    │  (include main_tools when worker needs tool awareness)
     ▼
 sessions_spawn(task=<enriched_task>, ...)
 ```
@@ -577,9 +578,13 @@ sessions_spawn(task=<enriched_task>, ...)
 ## Main Session Context
 {parent_session_summary}
 
+## Main Tools
+{main_tools_content}
+
 ## Guidance
 - Work in: {project_path}
 - Follow project conventions
+- Refer to Main Tools for available system capabilities and restrictions
 ```
 
 ### Implementation Pattern
@@ -603,9 +608,10 @@ async def dispatch_with_context(worker_type, task, context_hints=None):
     related_files = context_hints.get("related_files", infer_related_files(task))
     git_ctx = gather_git_context(project_path, files=related_files, depth=5)
     
-    # 3. Get memory context
+    # 3. Get memory context (includes main_tools)
     memory_ctx = await sync_main_context()
     parent_summary = memory_ctx.get("parent_history_summary", "N/A")
+    main_tools = memory_ctx.get("main_tools", "")
     
     # 4. Compose enriched task
     enriched_task = f"""\
@@ -620,10 +626,20 @@ async def dispatch_with_context(worker_type, task, context_hints=None):
 
 ## Main Session Context
 {parent_summary}
-
+"""
+    
+    # Include main tools when available
+    if main_tools:
+        enriched_task += f"""\
+## Main Tools
+{main_tools}
+"""
+    
+    enriched_task += f"""\
 ## Guidance
 - Work in: {project_info.path}
 - Follow project conventions for {project_info.type}
+- Refer to Main Tools for available system capabilities and restrictions
 """
     
     # 5. Dispatch with enriched task
@@ -638,10 +654,11 @@ async def dispatch_with_context(worker_type, task, context_hints=None):
 
 | Worker Type | Priority Context |
 |-------------|------------------|
-| `oe-script_coder` | Git changes, project type, coding conventions |
-| `oe-searcher` | Main session intent, topic context |
-| `oe-syshelper` | Project structure, file locations |
+| `oe-script_coder` | Git changes, project type, coding conventions, main tools (for tool awareness) |
+| `oe-searcher` | Main session intent, topic context, main tools (for available search tools) |
+| `oe-syshelper` | Project structure, file locations, main tools (for introspection tools) |
 | `oe-watchdog` | Session state, timeout expectations |
+| `oe-tool-recovery` | Main tools (critical — needs full tool landscape to diagnose failures) |
 
 ### What NOT to Include
 
@@ -652,7 +669,7 @@ async def dispatch_with_context(worker_type, task, context_hints=None):
 
 ### Integration with Skills
 
-- **`oe-memory-sync`**: Call `sync_main_context()` to get parent session summary
+- **`oe-memory-sync`**: Call `sync_main_context()` to get parent session summary **and main tools**
 - **`oe-git-context`**: Call `gather_git_context()` with related files
 - **`oe-project-registry`**: Call `get_project_info()` or `detect_project()`
 


### PR DESCRIPTION
## Summary

Main agent was bypassing tool restrictions (exec, web_search, etc.) and executing directly instead of routing to oe-orchestrator. The `before_tool_call` runtime hook in oe-runtime extension was never loaded because the extension was silently dropped from `openclaw.json` during installation.

## Root Cause

`_install_extension()` ran **before** `_configure_agent_models()` in the installer. Both write to `openclaw.json`:
1. `_install_extension()` → `openclaw plugins install --link` → writes oe-runtime to `plugins.allow` + `plugins.entries`
2. `_configure_agent_models()` → `_load_openclaw_config()` → modify agents → `_write_openclaw_config()` → **overwrites the entire file**, losing the plugins config from step 1

Verified via backup file forensics: `.bak.2` (post-extension-install) had oe-runtime, `.bak` (final state) did not.

## Changes

### Bug Fix (Critical)
- **installer.py**: Move `_install_extension()` after all `_write_openclaw_config` callers so it's the last thing to touch `openclaw.json`
- **installer.py**: Add `_verify_extension_in_config()` — post-install verification that oe-runtime actually persists in config, raises `InstallError` if not

### Tool Gate Enhancement
- **index.ts**: Add `web_search` and `web_fetch` to `MAIN_FORBIDDEN_TOOLS` (previously only blocked edit/write/exec/process/browser/playwright)
- **main_tool_gate.py**: Update prompt-level tool gate text to mention `web_search`/`web_fetch`

### Orchestrator Context (from prior session)
- **oe-memory-sync SKILL.md**: Add Main TOOLS.md as 5th context source
- **oe-worker-dispatch SKILL.md**: Pass main tools to workers during dispatch enrichment
- **oe-orchestrator AGENTS.md**: Update session startup docs, consolidate duplicate Skills section, bump to v1.4.0

## Verification

- ✅ Full reinstall: oe-runtime survives in `openclaw.json` after `python -m openclaw_enhance.cli install`
- ✅ Gateway restart: `openclaw plugins list` shows oe-runtime as `loaded`
- ✅ `MAIN_FORBIDDEN_TOOLS` now includes 8 tools (was 6)