### PR TITLE
fix: close #31 handle plain main session key in runtime gate

### DIFF
--- a/extensions/openclaw-enhance-runtime/index.ts
+++ b/extensions/openclaw-enhance-runtime/index.ts
@@ -16,7 +16,8 @@ const MAIN_FORBIDDEN_TOOLS = new Set([
 const mainRunIds = new Set<string>();
 
 const isMainSession = (sessionKey: unknown): boolean =>
-  typeof sessionKey === "string" && sessionKey.startsWith("agent:main:");
+  typeof sessionKey === "string" &&
+  (sessionKey === "main" || sessionKey.startsWith("agent:main:"));
 
 export default {
   id: "oe-runtime",

--- a/extensions/openclaw-enhance-runtime/src/runtime-bridge.test.ts
+++ b/extensions/openclaw-enhance-runtime/src/runtime-bridge.test.ts
@@ -365,6 +365,18 @@ describe("oe-runtime tool gate (index.ts)", () => {
       }
     });
 
+    it("should treat plain main sessionKey as main and block forbidden tools", async () => {
+      const api = createMockApi();
+      const plugin = await loadPlugin();
+      plugin.register(api);
+      api.simulateAgentEvent({ type: "run_start", runId: "main-run-plain", sessionKey: "main" });
+      const handler = api.handlers.get("before_tool_call")!;
+
+      const result = await handler({ runId: "main-run-plain", toolName: "edit" }) as { block: boolean } | undefined;
+      assert.ok(result);
+      assert.strictEqual((result as { block: boolean }).block, true);
+    });
+
     it("should not block when runId is unknown (not registered as main)", async () => {
       const api = createMockApi();
       const plugin = await loadPlugin();


### PR DESCRIPTION
## Summary
- expand runtime gate main-session detection to accept both `main` and `agent:main:*`
- add regression test proving `sessionKey=main` runIds are tracked and forbidden tools are blocked
- keep existing runId-based gating behavior unchanged for non-main sessions

## Verification
- npm test
- npm run typecheck
- npm run build