### PR TITLE
fix(cli): improve render-workspace error when no workspaces registered

### DIFF
--- a/src/openclaw_enhance/cli.py
+++ b/src/openclaw_enhance/cli.py
@@ -276,8 +276,14 @@ def render_workspace(workspace_name: str) -> None:
         rendered = render_workspace(workspace_name)
         click.echo(rendered)
     except ValueError as e:
-        available = ", ".join(list_workspaces()) if list_workspaces() else "none"
-        raise click.ClickException(f"{e}. Available workspaces: {available}") from e
+        workspaces = list_workspaces()
+        if workspaces:
+            available = ", ".join(workspaces)
+            raise click.ClickException(f"{e}. Available workspaces: {available}") from e
+        else:
+            raise click.ClickException(
+                f"{e}. No workspaces registered. See docs for how to set up a workspace."
+            ) from e
 
 
 # Registry of hook contracts for rendering


### PR DESCRIPTION
## Summary

Fixes the `render-workspace` command error message when no workspaces are registered. Previously showed `Available workspaces: none` which looked like `none` was a workspace name. Now shows a more informative message.

## Changes

- `src/openclaw_enhance/cli.py`: Improved error branching in `render_workspace` to distinguish between "no workspaces" vs "here are available workspaces"

## Testing

- All 23 CLI smoke tests pass
- mypy type check passes on the changed file
- Fixes #33