### PR TITLE
fix(install): correct skills and SOUL paths for OpenClaw v2

### DIFF
--- a/.sisyphus/evidence/task-4-fallback-default.txt
+++ b/.sisyphus/evidence/task-4-fallback-default.txt
@@ -4,7 +4,7 @@
   "project_type": "unknown",
   "project_subtype": "",
   "project_kind": "temporary",
-  "working_dir": "/private/var/folders/bc/pj_fw1k92xdf_p28cdfmhfd40000gn/T/pytest-of-tsgsz/pytest-861/test_resolve_fallback_default1/empty",
+  "working_dir": "/private/var/folders/bc/pj_fw1k92xdf_p28cdfmhfd40000gn/T/pytest-of-tsgsz/pytest-867/test_resolve_fallback_default1/empty",
   "git_context": null,
   "metadata": {}
 }

--- a/.sisyphus/evidence/task-4-full-context.txt
+++ b/.sisyphus/evidence/task-4-full-context.txt
@@ -1,10 +1,10 @@
 {
-  "project_id": "/private/var/folders/bc/pj_fw1k92xdf_p28cdfmhfd40000gn/T/pytest-of-tsgsz/pytest-861/test_build_project_context_reg1/my-project",
+  "project_id": "/private/var/folders/bc/pj_fw1k92xdf_p28cdfmhfd40000gn/T/pytest-of-tsgsz/pytest-867/test_build_project_context_reg1/my-project",
   "project_name": "my-project",
   "project_type": "python",
   "project_subtype": "setuptools",
   "project_kind": "permanent",
-  "working_dir": "/private/var/folders/bc/pj_fw1k92xdf_p28cdfmhfd40000gn/T/pytest-of-tsgsz/pytest-861/test_build_project_context_reg1/my-project",
+  "working_dir": "/private/var/folders/bc/pj_fw1k92xdf_p28cdfmhfd40000gn/T/pytest-of-tsgsz/pytest-867/test_build_project_context_reg1/my-project",
   "git_context": null,
   "metadata": {}
 }

--- a/src/openclaw_enhance/cli.py
+++ b/src/openclaw_enhance/cli.py
@@ -124,7 +124,7 @@ def install(
 def _inject_soul_to_main() -> None:
     """Inject SOUL content into main's SOUL.md file."""
     openclaw_home = Path.home() / ".openclaw"
-    soul_file = openclaw_home / "workspace" / "main" / "SOUL.md"
+    soul_file = openclaw_home / "workspace" / "SOUL.md"
 
     soul_content = """<!-- oe-soul-start -->
 ## Main Agent SOUL
@@ -164,7 +164,7 @@ You are the orchestration layer. Your rules:
 def _remove_soul_from_main() -> None:
     """Remove SOUL content from main's SOUL.md file."""
     openclaw_home = Path.home() / ".openclaw"
-    soul_file = openclaw_home / "workspace" / "main" / "SOUL.md"
+    soul_file = openclaw_home / "workspace" / "SOUL.md"
 
     if not soul_file.exists():
         click.echo(f"SOUL file does not exist: {soul_file}")
@@ -204,7 +204,7 @@ def _install_skills(target: str, skill_name: str | None, dry_run: bool) -> None:
     openclaw_home = Path.home() / ".openclaw"
 
     if target == "main":
-        skills_dir = openclaw_home / "workspace" / "main" / "skills"
+        skills_dir = openclaw_home / "workspace" / "skills"
     else:
         skills_dir = openclaw_home / "openclaw-enhance" / "skills"
 


### PR DESCRIPTION
## Summary

Fix incorrect installation paths:

- Skills now install to `~/.openclaw/workspace/skills/` (was `~/.openclaw/workspace/main/skills/`)
- SOUL now injects to `~/.openclaw/workspace/SOUL.md` (was `~/.openclaw/workspace/main/SOUL.md`)

## Verification

- 586 tests pass
- Skills installed to correct location
- SOUL injected correctly